### PR TITLE
Package.getStylesheetsPath is deprecated

### DIFF
--- a/stylesheets/wrap-lines.less
+++ b/stylesheets/wrap-lines.less
@@ -1,8 +1,0 @@
-// The ui-variables file is provided by base themes provided by Atom.
-//
-// See https://github.com/atom/atom-dark-ui/blob/master/stylesheets/ui-variables.less
-// for a full listing of what's available.
-@import "ui-variables";
-
-.wrap-lines {
-}


### PR DESCRIPTION
Removes the stylesheet, because its not used.

Fixes issue #11.